### PR TITLE
Fix multiple issues found during code review

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ping-async"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["hankbao <hankbao84@gmail.com>"]
 license = "MIT"
 description = "Unprivileged Async Ping"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ futures = "0.3"
 static_assertions = "1.1.0"
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.61.3"
+version = "0.62.2"
 features = [
     "Win32_Foundation",
     "Win32_Networking_WinSock",
@@ -30,8 +30,8 @@ features = [
 
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 rand = "0.9.2"
-socket2 = "0.6.0"
-tokio = { version = "1.47.0", features = [
+socket2 = "0.6.2"
+tokio = { version = "1.49.0", features = [
     "macros",
     "net",
     "rt",
@@ -40,7 +40,7 @@ tokio = { version = "1.47.0", features = [
 ] }
 
 [dev-dependencies]
-tokio = { version = "1.47.0", features = [
+tokio = { version = "1.49.0", features = [
     "macros",
     "rt-multi-thread",
     "time",


### PR DESCRIPTION
## Summary

1. Fix ICMP checksum verification tautology (`||` to `&&` for IPv6 skip logic)
2. Add `parse_error_reply()` to handle ICMP Destination Unreachable and Time Exceeded messages by extracting identifier/sequence from the embedded original echo request (IPv4 and IPv6)
3. Make router failure persistent so all subsequent `send()` calls fail fast with a consistent error instead of consuming it once
4. Register in the request registry before `send_to()` to prevent a race where fast loopback replies arrive before the entry exists
5. Fix potential underflow in timeout RTT calculation using `saturating_sub`
6. Read macOS IPv4 IP header length from IHL nibble instead of hardcoding 20 bytes
7. Update dependencies: `windows` 0.62.2, `socket2` 0.6.2, `tokio` 1.49.0
